### PR TITLE
fix: fix versions sorting

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -8,4 +8,4 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-list_all_versions | sort_versions | xargs echo
+list_all_versions | xargs echo


### PR DESCRIPTION
Fix versions sorting by removing `sort_versions` function from `bin/list-all`. This plugin was not working properly due to incorrect version sorting. This caused, the `latest` argument was not honored, neither versions were displayed properly.

## Before

`latest` not installing the latest version`:
```
$ asdf install teleport-community latest
mkdir: cannot create directory ‘/home/stano/.asdf/downloads/teleport-community/9.3.26’: File exists
* Downloading teleport-community release 9.3.26...
```

Incorrect sorting:
```
$ asdf list-all teleport-community
0.0.11
1.0.0
1.0.3
1.0.4
1.0.5
1.1.0
1.2.0
1.2.6
1.3.0
1.3.1
1.3.2
10.0.0
10.0.1
10.0.2
10.1.0
10.1.1
10.1.2
10.1.3
...
12.1.0
12.1.1
12.1.3
12.1.4
12.1.5
2.0.1
2.0.2
2.0.3
2.0.4
...
9.3.20
9.3.21
9.3.22
9.3.23
9.3.25
9.3.26
```

## After

`latest` version honored:
```
$ asdf install teleport-community latest
* Downloading teleport-community release 12.1.5...
teleport-community 12.1.5 installation was successful!
```

Versions properly sorted:
```
$ asdf list-all teleport-community
0.0.11
1.0.0
1.0.3
1.0.4
...
12.1.4
12.1.5
```