### PR TITLE
Fix v17 installation

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -108,6 +108,8 @@ install_version() {
   local version="$2"
   local install_path="$3"
 
+  major_version=$(echo "$version" | cut -d. -f1)
+
   if [ "$install_type" != "version" ]; then
     fail "asdf-$TOOL_NAME supports release installs only"
   fi
@@ -119,9 +121,14 @@ install_version() {
 
     mkdir -p "$install_path"/bin
     mv "$install_path"/teleport "$install_path"/bin/teleport
-    mv "$install_path"/tctl "$install_path"/bin/tctl
-    mv "$install_path"/tsh "$install_path"/bin/tsh
     mv "$install_path"/tbot "$install_path"/bin/tbot
+    if [ "$major_version" -gt 16 ]; then
+      mv "$install_path"/tctl.app/Contents/MacOS/tctl "$install_path"/bin/tctl
+      mv "$install_path"/tsh.app/Contents/MacOS/tsh "$install_path"/bin/tsh
+    else
+      mv "$install_path"/tctl "$install_path"/bin/tctl
+      mv "$install_path"/tsh "$install_path"/bin/tsh
+    fi
 
     local tool_cmd
     tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -109,6 +109,7 @@ install_version() {
   local install_path="$3"
 
   major_version=$(echo "$version" | cut -d. -f1)
+  os=$(detect_os)
 
   if [ "$install_type" != "version" ]; then
     fail "asdf-$TOOL_NAME supports release installs only"
@@ -122,7 +123,7 @@ install_version() {
     mkdir -p "$install_path"/bin
     mv "$install_path"/teleport "$install_path"/bin/teleport
     mv "$install_path"/tbot "$install_path"/bin/tbot
-    if [ "$major_version" -gt 16 ]; then
+    if [ "$os" = "darwin" ] && [ "$major_version" -gt 16 ]; then
       mv "$install_path"/tctl.app/Contents/MacOS/tctl "$install_path"/bin/tctl
       mv "$install_path"/tsh.app/Contents/MacOS/tsh "$install_path"/bin/tsh
     else

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -123,7 +123,7 @@ install_version() {
     mkdir -p "$install_path"/bin
     mv "$install_path"/teleport "$install_path"/bin/teleport
     mv "$install_path"/tbot "$install_path"/bin/tbot
-    if [ "$os" = "darwin" ] && [ "$major_version" -gt 16 ]; then
+    if [ "$os" = "darwin" ] && [ "$major_version" -gt "16" ]; then
       mv "$install_path"/tctl.app/Contents/MacOS/tctl "$install_path"/bin/tctl
       mv "$install_path"/tsh.app/Contents/MacOS/tsh "$install_path"/bin/tsh
     else

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -124,8 +124,8 @@ install_version() {
     mv "$install_path"/teleport "$install_path"/bin/teleport
     mv "$install_path"/tbot "$install_path"/bin/tbot
     if [ "$os" = "darwin" ] && [ "$major_version" -gt "16" ]; then
-      mv "$install_path"/tctl.app/Contents/MacOS/tctl "$install_path"/bin/tctl
-      mv "$install_path"/tsh.app/Contents/MacOS/tsh "$install_path"/bin/tsh
+      ln -s "$install_path/tsh.app/Contents/MacOS/tsh" "$install_path/bin/tsh"
+      ln -s "$install_path/tctl.app/Contents/MacOS/tctl" "$install_path/bin/tctl"
     else
       mv "$install_path"/tctl "$install_path"/bin/tctl
       mv "$install_path"/tsh "$install_path"/bin/tsh


### PR DESCRIPTION
The latest version of teleport-community is failing to install in macOS due to changed paths for `tctl` and `tsh` binaries.

```
$ asdf install teleport-community latest
* Downloading teleport-community release 17.0.2...
mv: rename /Users/localuser/.asdf/installs/teleport-community/17.0.2/tctl to /Users/localuser/.asdf/installs/teleport-community/17.0.2/bin/tctl: No such file or directory
mv: rename /Users/localuser/.asdf/installs/teleport-community/17.0.2/tsh to /Users/localuser/.asdf/installs/teleport-community/17.0.2/bin/tsh: No such file or directory
asdf-teleport-community: Expected /Users/localuser/.asdf/installs/teleport-community/17.0.2/bin/tsh to be executable.
asdf-teleport-community: An error occurred while installing teleport-community 17.0.2.
```

Here is the structure of the extracted archive:
```
$ ls -1 ~/.asdf/downloads/teleport-community/17.0.2/
CHANGELOG.md
README.md
VERSION
examples
fdpass-teleport
install
tbot
tctl.app
teleport
tsh.app
```

The `tctl` and `tsh` binaries are now located in:
- `"$install_path"/tctl.app/Contents/MacOS/tctl`
- `"$install_path"/tsh.app/Contents/MacOS/tsh`

The [official install script](https://github.com/gravitational/teleport/blob/master/build.assets/macos/install#L48-L60) symlinks those binaries instead of moving them.